### PR TITLE
move detail::computedPropName to RDKit::detail::computedPropName

### DIFF
--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -115,12 +115,12 @@ void _MolToSDStream(std::ostream *dp_ostream, const ROMol &mol, int confId,
     // out to the file
     STR_VECT properties = mol.getPropList();
     STR_VECT compLst;
-    mol.getPropIfPresent(detail::computedPropName, compLst);
+    mol.getPropIfPresent(RDKit::detail::computedPropName, compLst);
 
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
-      if (((*pi) == detail::computedPropName) ||
+      if (((*pi) == RDKit::detail::computedPropName) ||
           ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
           ((*pi) == "_MolFileComments") ||
           ((*pi) == common_properties::_MolFileChiralFlag)) {

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -137,12 +137,12 @@ void TDTWriter::write(const ROMol &mol, int confId) {
     // out to the file
     STR_VECT properties = mol.getPropList();
     STR_VECT compLst;
-    mol.getPropIfPresent(detail::computedPropName, compLst);
+    mol.getPropIfPresent(RDKit::detail::computedPropName, compLst);
 
     STR_VECT_CI pi;
     for (pi = properties.begin(); pi != properties.end(); pi++) {
       // ignore any of the following properties
-      if (((*pi) == detail::computedPropName) ||
+      if (((*pi) == RDKit::detail::computedPropName) ||
           ((*pi) == common_properties::_Name) || ((*pi) == "_MolFileInfo") ||
           ((*pi) == "_MolFileComments") ||
           ((*pi) == common_properties::_MolFileChiralFlag)) {

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -98,7 +98,7 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
   } else {
     dp_props.reset();
     STR_VECT computed;
-    dp_props.setVal(detail::computedPropName, computed);
+    dp_props.setVal(RDKit::detail::computedPropName, computed);
   }
   // std::cerr<<"---------    done init from other: "<<this<<"
   // "<<&other<<std::endl;
@@ -107,14 +107,14 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
 void ROMol::initMol() {
   dp_props.reset();
   dp_ringInfo = new RingInfo();
-  // ok every molecule contains a property entry called detail::computedPropName
+  // ok every molecule contains a property entry called RDKit::detail::computedPropName
   // which provides
   //  list of property keys that correspond to value that have been computed
   // this can used to blow out all computed properties while leaving the rest
   // along
   // initialize this list to an empty vector of strings
   STR_VECT computed;
-  dp_props.setVal(detail::computedPropName, computed);
+  dp_props.setVal(RDKit::detail::computedPropName, computed);
 }
 
 unsigned int ROMol::getAtomDegree(const Atom *at) const {

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -216,7 +216,7 @@ class RWMol : public ROMol {
     d_confs.clear();
     dp_props.reset();
     STR_VECT computed;
-    dp_props.setVal(detail::computedPropName, computed);
+    dp_props.setVal(RDKit::detail::computedPropName, computed);
 
     if (dp_ringInfo) dp_ringInfo->reset();
   };

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -161,7 +161,7 @@ void testMolProps() {
   m2.setProp("cprop1", 1, true);
   m2.setProp("cprop2", 2, true);
   STR_VECT cplst;
-  m2.getProp(detail::computedPropName, cplst);
+  m2.getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 2, "");
   CHECK_INVARIANT(cplst[0] == "cprop1", "");
   CHECK_INVARIANT(cplst[1] == "cprop2", "");
@@ -179,12 +179,12 @@ void testMolProps() {
 
   m2.clearProp("cprop1");
   CHECK_INVARIANT(!m2.hasProp("cprop1"), "");
-  m2.getProp(detail::computedPropName, cplst);
+  m2.getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 1, "");
 
   m2.clearComputedProps();
   CHECK_INVARIANT(!m2.hasProp("cprop2"), "");
-  m2.getProp(detail::computedPropName, cplst);
+  m2.getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 0, "");
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -206,7 +206,7 @@ void testClearMol() {
   m2.getProp("prop1", tmpI);
   TEST_ASSERT(tmpI == 2);
 
-  TEST_ASSERT(m2.hasProp(detail::computedPropName));
+  TEST_ASSERT(m2.hasProp(RDKit::detail::computedPropName));
 
   m2.clear();
   TEST_ASSERT(!m2.hasProp("prop1"));
@@ -215,7 +215,7 @@ void testClearMol() {
   TEST_ASSERT(m2.getAtomBookmarks()->empty());
   TEST_ASSERT(m2.getBondBookmarks()->empty());
 
-  TEST_ASSERT(m2.hasProp(detail::computedPropName));  // <- github issue 176
+  TEST_ASSERT(m2.hasProp(RDKit::detail::computedPropName));  // <- github issue 176
   TEST_ASSERT(m2.getPropList().size() == 1);
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -287,19 +287,19 @@ void testAtomProps() {
   a1->setProp("cprop1", 1, true);
   a1->setProp("cprop2", 2, true);
   STR_VECT cplst;
-  a1->getProp(detail::computedPropName, cplst);
+  a1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 2, "");
   CHECK_INVARIANT(cplst[0] == "cprop1", "");
   CHECK_INVARIANT(cplst[1] == "cprop2", "");
 
   a1->clearProp("cprop1");
   CHECK_INVARIANT(!a1->hasProp("cprop1"), "");
-  a1->getProp(detail::computedPropName, cplst);
+  a1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 1, "");
 
   a1->clearComputedProps();
   CHECK_INVARIANT(!a1->hasProp("cprop2"), "");
-  a1->getProp(detail::computedPropName, cplst);
+  a1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 0, "");
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -342,19 +342,19 @@ void testBondProps() {
   b1->setProp("cprop1", 1, true);
   b1->setProp("cprop2", 2, true);
   STR_VECT cplst;
-  b1->getProp(detail::computedPropName, cplst);
+  b1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 2, "");
   CHECK_INVARIANT(cplst[0] == "cprop1", "");
   CHECK_INVARIANT(cplst[1] == "cprop2", "");
 
   b1->clearProp("cprop1");
   CHECK_INVARIANT(!b1->hasProp("cprop1"), "");
-  b1->getProp(detail::computedPropName, cplst);
+  b1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 1, "");
 
   b1->clearComputedProps();
   CHECK_INVARIANT(!b1->hasProp("cprop2"), "");
-  b1->getProp(detail::computedPropName, cplst);
+  b1->getProp(RDKit::detail::computedPropName, cplst);
   CHECK_INVARIANT(cplst.size() == 0, "");
 
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -34,8 +34,8 @@ protected:
     const STR_VECT &tmp = dp_props.keys();
     STR_VECT res, computed;
     if (!includeComputed &&
-        getPropIfPresent(detail::computedPropName, computed)) {
-      computed.push_back(detail::computedPropName);
+        getPropIfPresent(RDKit::detail::computedPropName, computed)) {
+      computed.push_back(RDKit::detail::computedPropName);
     }
 
     STR_VECT::const_iterator pos = tmp.begin();
@@ -48,7 +48,7 @@ protected:
     }
     return res;
   }
-  
+
   //! sets a \c property value
   /*!
     \param key the name under which the \c property should be stored.
@@ -64,10 +64,10 @@ protected:
   void setProp(const std::string &key, T val, bool computed = false) const {
     if (computed) {
       STR_VECT compLst;
-      getPropIfPresent(detail::computedPropName, compLst);
+      getPropIfPresent(RDKit::detail::computedPropName, compLst);
       if (std::find(compLst.begin(), compLst.end(), key) == compLst.end()) {
         compLst.push_back(key);
-        dp_props.setVal(detail::computedPropName, compLst);
+        dp_props.setVal(RDKit::detail::computedPropName, compLst);
       }
     }
     // setProp(key.c_str(),val);
@@ -126,11 +126,11 @@ protected:
   //! \overload
   void clearProp(const std::string &key) const {
     STR_VECT compLst;
-    if (getPropIfPresent(detail::computedPropName, compLst)) {
+    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
       STR_VECT_I svi = std::find(compLst.begin(), compLst.end(), key);
       if (svi != compLst.end()) {
         compLst.erase(svi);
-        dp_props.setVal(detail::computedPropName, compLst);
+        dp_props.setVal(RDKit::detail::computedPropName, compLst);
       }
     }
     dp_props.clearVal(key);
@@ -139,10 +139,10 @@ protected:
   //! clears all of our \c computed \c properties
   void clearComputedProps() const {
     STR_VECT compLst;
-    if (getPropIfPresent(detail::computedPropName, compLst)) {
+    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
       BOOST_FOREACH (const std::string &sv, compLst) { dp_props.clearVal(sv); }
       compLst.clear();
-      dp_props.setVal(detail::computedPropName, compLst);
+      dp_props.setVal(RDKit::detail::computedPropName, compLst);
     }
   }
 };

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -37,18 +37,18 @@ void testGithub940() {
   {  // tests computed props
     STR_VECT computed;
     Dict *d = new Dict();
-    d->setVal(detail::computedPropName, computed);
+    d->setVal(RDKit::detail::computedPropName, computed);
     computed.push_back("foo");
-    d->setVal(detail::computedPropName, computed);
+    d->setVal(RDKit::detail::computedPropName, computed);
     delete d;
   }
   {  // tests computed props
     STR_VECT computed;
     Dict *d = new Dict();
-    d->setVal(detail::computedPropName, computed);
+    d->setVal(RDKit::detail::computedPropName, computed);
     computed.push_back("foo");
-    d->setVal(detail::computedPropName, computed);
-    d->clearVal(detail::computedPropName);
+    d->setVal(RDKit::detail::computedPropName, computed);
+    d->clearVal(RDKit::detail::computedPropName);
     delete d;
   }
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
@@ -110,13 +110,13 @@ void testRDAny() {
   { // tests computed props
     STR_VECT computed;
     Dict d;
-    d.setVal(detail::computedPropName, computed);
+    d.setVal(RDKit::detail::computedPropName, computed);
     computed.push_back("foo");
-    d.setVal(detail::computedPropName, computed);
-    STR_VECT computed2 = d.getVal<STR_VECT>(detail::computedPropName);
+    d.setVal(RDKit::detail::computedPropName, computed);
+    STR_VECT computed2 = d.getVal<STR_VECT>(RDKit::detail::computedPropName);
     TEST_ASSERT(computed2[0] == "foo");
     Dict d2(d);
-    computed2 = d2.getVal<STR_VECT>(detail::computedPropName);
+    computed2 = d2.getVal<STR_VECT>(RDKit::detail::computedPropName);
     TEST_ASSERT(computed2[0] == "foo");
   }
   

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -14,6 +14,10 @@
 #include "types.h"
 
 namespace RDKit {
+  namespace detail {
+  const std::string computedPropName = "__computedProps";
+  }
+
 namespace common_properties {
 const std::string TWOD = "2D";
 const std::string BalabanJ = "BalabanJ";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -20,11 +20,6 @@
 #include "Invariant.h"
 #include "Dict.h"
 
-namespace detail {
-// used in various places for computed properties
-const std::string computedPropName = "__computedProps";
-}
-
 #include <vector>
 #include <deque>
 #include <map>
@@ -41,6 +36,12 @@ const std::string computedPropName = "__computedProps";
 #include <boost/lexical_cast.hpp>
 
 namespace RDKit {
+
+  namespace detail {
+  // used in various places for computed properties
+  extern const std::string computedPropName;
+  }
+
 namespace common_properties {
 ///////////////////////////////////////////////////////////////
 // Molecule Props
@@ -50,19 +51,19 @@ extern const std::string MolFileComments; // string
 extern const std::string _2DConf;         // int (combine into dimension?)
 extern const std::string _3DConf;         // int
 extern const std::string _doIsoSmiles;    // int (should probably be removed)
-extern const std::string extraRings;      // vec<vec<int> > 
+extern const std::string extraRings;      // vec<vec<int> >
 extern const std::string _smilesAtomOutputOrder; // vec<int> computed
-extern const std::string _StereochemDone; // int 
+extern const std::string _StereochemDone; // int
 extern const std::string _NeedsQueryScan; // int (bool)
 extern const std::string _fragSMARTS;     // std::string
 extern const std::string maxAttachIdx;    // int TemplEnumTools.cpp
-extern const std::string origNoImplicit;  // int (bool) 
+extern const std::string origNoImplicit;  // int (bool)
 extern const std::string ringMembership;  //? unused (molopstest.cpp)
 
 // Computed Values
 // ConnectivityDescriptors
-extern const std::string _connectivityHKDeltas;// std::vector<double> computed 
-extern const std::string _connectivityNVals;   // std::vector<double> computed 
+extern const std::string _connectivityHKDeltas;// std::vector<double> computed
+extern const std::string _connectivityNVals;   // std::vector<double> computed
 
 extern const std::string _crippenLogP;         // double computed
 extern const std::string _crippenLogPContribs; // std::vector<double> computed
@@ -87,7 +88,7 @@ extern const std::string _CrippenMR;   // Unused (in the basement)
 // Atom Props
 
 // Chirality stuff
-extern const std::string _BondsPotentialStereo; // int (or bool) COMPUTED 
+extern const std::string _BondsPotentialStereo; // int (or bool) COMPUTED
 extern const std::string _CIPCode; // std::string COMPUTED
 extern const std::string _CIPRank; // int COMPUTED
 extern const std::string _ChiralityPossible; // int
@@ -99,7 +100,7 @@ extern const std::string _ringStereoWarning; // obsolete ?
 // Smiles parsing
 extern const std::string _SmilesStart; // int
 extern const std::string _TraversalBondIndexOrder; // ? unused
-extern const std::string _TraversalRingClosureBond; // unsigned int 
+extern const std::string _TraversalRingClosureBond; // unsigned int
 extern const std::string _TraversalStartPoint; // bool
 extern const std::string _queryRootAtom; // int SLNParse/SubstructMatch
 extern const std::string _hasMassQuery; // atom bool
@@ -109,25 +110,25 @@ extern const std::string _unspecifiedOrder;// atom int (bool) smarts/smiles
 extern const std::string _RingClosures; // INT_VECT smarts/smiles/canon
 
 // MDL Style Properties (MolFileParser)
-extern const std::string molAtomMapNumber; // int 
-extern const std::string molFileAlias;  // string 
-extern const std::string molFileValue;  // string 
-extern const std::string molInversionFlag; // int 
-extern const std::string molParity;     // int 
-extern const std::string molRxnComponent; // int 
-extern const std::string molRxnRole;    // int 
-extern const std::string molTotValence; // int 
+extern const std::string molAtomMapNumber; // int
+extern const std::string molFileAlias;  // string
+extern const std::string molFileValue;  // string
+extern const std::string molInversionFlag; // int
+extern const std::string molParity;     // int
+extern const std::string molRxnComponent; // int
+extern const std::string molRxnRole;    // int
+extern const std::string molTotValence; // int
 extern const std::string _MolFileRLabel; // int
 extern const std::string _MolFileChiralFlag; // int
 
 extern const std::string dummyLabel; // atom string
 
 // Reaction Information (Reactions.cpp)
-extern const std::string _QueryFormalCharge; //  int 
-extern const std::string _QueryHCount; // int 
+extern const std::string _QueryFormalCharge; //  int
+extern const std::string _QueryHCount; // int
 extern const std::string _QueryIsotope; // int
-extern const std::string _QueryMass; // int = round(float * 1000) 
-extern const std::string _ReactionDegreeChanged; // int (bool) 
+extern const std::string _QueryMass; // int = round(float * 1000)
+extern const std::string _ReactionDegreeChanged; // int (bool)
 extern const std::string NullBond; // int (bool)
 extern const std::string _rgroupAtomMaps;
 extern const std::string _rgroupBonds;
@@ -140,7 +141,7 @@ extern const std::string _Unfinished_SLN_; // int (bool)
 
 // Smarts Smiles
 extern const std::string _brokenChirality; // atom bool
-extern const std::string isImplicit;  // atom int (bool) 
+extern const std::string isImplicit;  // atom int (bool)
 extern const std::string smilesSymbol; // atom string (only used in test?)
 
 // Tripos


### PR DESCRIPTION
also moves the definition into types.cpp
