### PR TITLE
update swig wrappers

### DIFF
--- a/Code/JavaWrappers/Atom.i
+++ b/Code/JavaWrappers/Atom.i
@@ -1,21 +1,21 @@
-/* 
+/*
 * $Id: Atom.i 2519 2013-05-17 03:01:18Z glandrum $
 *
 *  Copyright (c) 2010, Novartis Institutes for BioMedical Research Inc.
 *  All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are
-* met: 
+* met:
 *
-*     * Redistributions of source code must retain the above copyright 
+*     * Redistributions of source code must retain the above copyright
 *       notice, this list of conditions and the following disclaimer.
 *     * Redistributions in binary form must reproduce the above
-*       copyright notice, this list of conditions and the following 
-*       disclaimer in the documentation and/or other materials provided 
+*       copyright notice, this list of conditions and the following
+*       disclaimer in the documentation and/or other materials provided
 *       with the distribution.
-*     * Neither the name of Novartis Institutes for BioMedical Research Inc. 
-*       nor the names of its contributors may be used to endorse or promote 
+*     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+*       nor the names of its contributors may be used to endorse or promote
 *       products derived from this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -100,11 +100,11 @@
 
   std::vector<RDKit::Bond*> *getBonds() {
     std::vector<RDKit::Bond*> *bonds = new std::vector<RDKit::Bond*>;
-    const RDKit::ROMol *parent = &($self)->getOwningMol();
+    RDKit::ROMol *parent = &($self)->getOwningMol();
     RDKit::ROMol::OEDGE_ITER begin,end;
     boost::tie(begin,end) = parent->getAtomBonds(($self));
     while(begin!=end){
-      RDKit::Bond *tmpB = (*parent)[*begin].get();
+      RDKit::Bond *tmpB = (*parent)[*begin];
       bonds->push_back(tmpB);
       begin++;
     }
@@ -112,4 +112,3 @@
   }
 
 }
-

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -68,19 +68,12 @@
 %template(Atom_Vect) std::vector<RDKit::Atom*>;
 
 // These prevent duplicate definitions in Java code
-%ignore RDKit::ROMol::getAtomDegree(const Atom *) const;
-%ignore RDKit::ROMol::setAtomBookmark(Atom *,int);
-%ignore RDKit::ROMol::clearAtomBookmark(const int, const Atom *);
-%ignore RDKit::ROMol::setBondBookmark(Bond *,int);
-%ignore RDKit::ROMol::clearBondBookmark(int, const Bond *);
-%ignore RDKit::ROMol::replaceAtomBookmark(Atom *,int);
 %ignore RDKit::ROMol::hasProp(std::string const) const ;
 %ignore RDKit::ROMol::clearProp(std::string const) const ;
 %ignore RDKit::ROMol::getAtomWithIdx(unsigned int) const ;
 %ignore RDKit::ROMol::getBondWithIdx(unsigned int) const ;
 %ignore RDKit::ROMol::getBondBetweenAtoms(unsigned int,unsigned int) const ;
 %ignore RDKit::ROMol::getAtomNeighbors(Atom const *at) const;
-%ignore RDKit::ROMol::getAtomNeighbors(ATOM_SPTR at) const;
 %ignore RDKit::ROMol::getAtomBonds(Atom const *at) const;
 %ignore RDKit::ROMol::getVertices() ;
 %ignore RDKit::ROMol::getVertices() const ;


### PR DESCRIPTION
a couple minor changes to make the SWIG wrappers work.
These now build and pass their tests.
The tests for the KNIME nodes (which also exercise a reasonable set of the wrappers) also all pass except for one expected failure.