### PR TITLE
Fix a problem with missing r groups

### DIFF
--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -508,9 +508,7 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrAromaticBondQuery() {
   res->setDataFunc(queryBondIsSingleOrAromatic);
   res->setDescription("SingleOrAromaticBond");
   return res;
-
 };
-
 
 BOND_EQUALS_QUERY *makeBondDirEqualsQuery(Bond::BondDir what) {
   auto *res = new BOND_EQUALS_QUERY;
@@ -593,7 +591,7 @@ bool _complexQueryHelper(Atom::QUERYATOM_QUERY const *query, bool &hasAtNum) {
   if (query->getNegation()) return true;
   std::string descr = query->getDescription();
   // std::cerr<<" |"<<descr;
-  if (descr == "AtomAtomicNum" || descr=="AtomType") {
+  if (descr == "AtomAtomicNum" || descr == "AtomType") {
     hasAtNum = true;
     return false;
   }
@@ -614,7 +612,8 @@ bool isComplexQuery(const Atom *a) {
   if (a->getQuery()->getNegation()) return true;
   std::string descr = a->getQuery()->getDescription();
   // std::cerr<<" "<<descr;
-  if (descr == "AtomAtomicNum" || descr == "AtomType") return false;
+  if (descr == "AtomNull" || descr == "AtomAtomicNum" || descr == "AtomType")
+    return false;
   if (descr == "AtomOr" || descr == "AtomXor") return true;
   if (descr == "AtomAnd") {
     bool hasAtNum = false;
@@ -642,7 +641,8 @@ bool isAtomAromatic(const Atom *a) {
       res = false;
       if (a->getQuery()->getNegation()) res = !res;
     } else if (descr == "AtomType") {
-      res = getAtomTypeIsAromatic(static_cast<ATOM_EQUALS_QUERY *>(a->getQuery())->getVal());
+      res = getAtomTypeIsAromatic(
+          static_cast<ATOM_EQUALS_QUERY *>(a->getQuery())->getVal());
       if (a->getQuery()->getNegation()) res = !res;
     } else if (descr == "AtomAnd") {
       auto childIt = a->getQuery()->beginChildren();

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -125,13 +125,13 @@ class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
 
 RDKIT_RGROUPDECOMPOSITION_EXPORT unsigned int RGroupDecompose(
     const std::vector<ROMOL_SPTR> &cores, const std::vector<ROMOL_SPTR> &mols,
-    RGroupRows &rows, std::vector<unsigned int> *unmatched = 0,
+    RGroupRows &rows, std::vector<unsigned int> *unmatched = nullptr,
     const RGroupDecompositionParameters &options =
         RGroupDecompositionParameters());
 
 RDKIT_RGROUPDECOMPOSITION_EXPORT unsigned int RGroupDecompose(
     const std::vector<ROMOL_SPTR> &cores, const std::vector<ROMOL_SPTR> &mols,
-    RGroupColumns &columns, std::vector<unsigned int> *unmatched = 0,
+    RGroupColumns &columns, std::vector<unsigned int> *unmatched = nullptr,
     const RGroupDecompositionParameters &options =
         RGroupDecompositionParameters());
 }  // namespace RDKit

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -839,20 +839,18 @@ void testNumHeteroatomNeighborQueries() {
   BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
 }
 
-
 void testAtomTypeQueries() {
-  BOOST_LOG(rdErrorLog)
-      << "---------------------- Test atom type queries"
-      << std::endl;
+  BOOST_LOG(rdErrorLog) << "---------------------- Test atom type queries"
+                        << std::endl;
 
   RWMol *m = SmilesToMol("CCc1ccccc1");
   {
     QueryAtom qA1;
-    qA1.setQuery(makeAtomTypeQuery(6,true));
+    qA1.setQuery(makeAtomTypeQuery(6, true));
     QueryAtom qA2;
-    qA2.setQuery(makeAtomTypeQuery(6,false));
+    qA2.setQuery(makeAtomTypeQuery(6, false));
     QueryAtom qA3;
-    qA3.setQuery(makeAtomTypeQuery(7,true));
+    qA3.setQuery(makeAtomTypeQuery(7, true));
     TEST_ASSERT(!qA1.Match(m->getAtomWithIdx(0)));
     TEST_ASSERT(qA2.Match(m->getAtomWithIdx(0)));
     TEST_ASSERT(!qA3.Match(m->getAtomWithIdx(0)));
@@ -862,6 +860,21 @@ void testAtomTypeQueries() {
   }
 
   delete m;
+  BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
+}
+
+void testGithub2471() {
+  BOOST_LOG(rdErrorLog) << "---------------------- Test Github #2471: dummy "
+                           "atom queries are flagged as complex"
+                        << std::endl;
+
+  auto m = "[*;$(CC)][*]"_smarts;
+  TEST_ASSERT(m);
+  TEST_ASSERT(m->getAtomWithIdx(0)->hasQuery());
+  TEST_ASSERT(m->getAtomWithIdx(1)->hasQuery());
+  TEST_ASSERT(isComplexQuery(m->getAtomWithIdx(0)));
+  TEST_ASSERT(!isComplexQuery(m->getAtomWithIdx(1)));
+
   BOOST_LOG(rdErrorLog) << "Done!" << std::endl;
 }
 
@@ -886,5 +899,6 @@ int main() {
   testExtraBondQueries();
   testNumHeteroatomNeighborQueries();
   testAtomTypeQueries();
+  testGithub2471();
   return 0;
 }


### PR DESCRIPTION
Demo:
```
    In [14]: scaffold2 = Chem.MolFromSmiles('c1c([*:1])cncn1')
    
    In [15]: scaffold = Chem.MolFromSmiles('c1c([*:1])cccn1')
    
    In [19]: mols2 = [Chem.MolFromSmiles(smi) for smi in 'c1c(F)cc(O)cn1 c1c(F)cncn1 c1c(Cl)cc(O)cn1'.split()]
    
    In [20]: print(rdRGroupDecomposition.RGroupDecompose([scaffold,scaffold2],mols2,asSmiles=True,asRows=False))
    ({'Core': ['c1ncc([*:2])cc1[*:1]', 'c1ncc([*:1])cn1', 'c1ncc([*:2])cc1[*:1]'], 'R1': ['F[*:1]', 'F[*:1]', 'Cl[*:1]'], 'R2': ['[H]O[*:2]', '[H]O[*:2]', '']}, [])
```

I figure it makes sense to wrap this into your broader RGD PR

The fix for #2471 isn't directly related to this, but it does affect R group reporting, so I'm sneaking it in. 